### PR TITLE
Kan 6 auth context refactor

### DIFF
--- a/src/components/features/Auth/LoginForm/LoginForm.tsx
+++ b/src/components/features/Auth/LoginForm/LoginForm.tsx
@@ -16,7 +16,7 @@ const LoginForm = () => {
 
 	useEffect(() => {
 		if (user) {
-			navigate("/profile")
+			 navigate(user.role === "FREELANCER" ? "/onboarding" : "/profile");
 		}
 	}, [ navigate, user ]);
 

--- a/src/components/features/EditModal/sales_tools/SalesToolsEditModalItem/SalesToolsEditModalItem.tsx
+++ b/src/components/features/EditModal/sales_tools/SalesToolsEditModalItem/SalesToolsEditModalItem.tsx
@@ -8,33 +8,32 @@ import DragAndDropContainer
 import {useModal} from "@context/ModalContext/ModalContext.ts";
 import SalesToolModalItem from "@components/features/EditModal/sales_tools/SalesToolModalItem/SalesToolModalItem.tsx";
 import { getPictureForSalesTools , getToolKindNameByKind} from "@utils/salesToolsUtils.ts";
-import { useFreelancerOnboardingService } from "@services/onboarding/freelancerOnboardingService.ts";
 import SalesToolsAddModalItem
 	from "@components/features/EditModal/sales_tools/SalesToolsAddModalItem/SalesToolsAddModalItem.tsx";
 import { useFreelancerProfileService } from "@services/freelancer/freelancerProfileService.ts";
 import { ISalesToolsEditModalItemProps } from "@components/features/EditModal/sales_tools/SalesToolsEditModalItem/SalesToolsEditModalItemTypes.ts";
 
-const SalesToolsEditModalItem: React.FC<ISalesToolsEditModalItemProps> = ({ registerOnSave, allSalesTools }) => {
+const SalesToolsEditModalItem: React.FC<ISalesToolsEditModalItemProps> = ({ registerOnSave, allSalesTools, onSave }) => {
 
-	const { user, getLoggedUserData } = useContext(AuthContext);
+	const { user } = useContext(AuthContext);
+
 	const { openModal } = useModal();
-	const { patchSalesTools } = useFreelancerOnboardingService();
+
 	const { getFreelancerSalesTools }= useFreelancerProfileService();
 
-	const [ salesTools, setSalesTools ] = useState<ISalesTool[]>(user?.salesTools || []);
+	const [ salesTools, setSalesTools ] = useState<ISalesTool[]>([]);
+
+	const handleSave = useCallback(() => {
+		onSave(salesTools);
+	}, [ onSave, salesTools ]);
 
 	useEffect(() => {
 		if (!user) return;
+
 		getFreelancerSalesTools(user.id)
 			.then(setSalesTools)
 			.catch(console.error);
 	}, [ getFreelancerSalesTools, user ]);
-
-	const handleSave = useCallback(() => {
-		patchSalesTools(salesTools.map(tool => tool.id))
-			.then(() => getLoggedUserData(localStorage.getItem('token')!))
-			.catch(console.error);
-	}, [ getLoggedUserData, patchSalesTools, salesTools ]);
 
 	useEffect(() => {
 		registerOnSave!(handleSave);

--- a/src/components/features/EditModal/sales_tools/SalesToolsEditModalItem/SalesToolsEditModalItemTypes.ts
+++ b/src/components/features/EditModal/sales_tools/SalesToolsEditModalItem/SalesToolsEditModalItemTypes.ts
@@ -3,6 +3,7 @@ import { ISaveableChildProps } from "@context/ModalContext/ModalContext.ts";
 
 export interface ISalesToolsEditModalItemProps extends ISaveableChildProps{
     allSalesTools: ISalesTool[];
+    onSave: (newSalesTools: ISalesTool[]) => void;
 }
 
 

--- a/src/components/features/EditModal/sectors/SectorsModalItem/SectorsModalItem.tsx
+++ b/src/components/features/EditModal/sectors/SectorsModalItem/SectorsModalItem.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
-import { ISectorsModalItemProps } from "@components/features/EditModal/sectors/SectorsModalItem/sectorsModalItemTypes.ts";
+import React, {useCallback, useContext, useEffect, useState} from "react";
+import {ISectorsModalItemProps} from "@components/features/EditModal/sectors/SectorsModalItem/sectorsModalItemTypes.ts";
 import styles from "./SectorsModalItem.module.scss";
-import { useFreelancerOnboardingService } from "@services/onboarding/freelancerOnboardingService.ts";
+import {useFreelancerOnboardingService} from "@services/onboarding/freelancerOnboardingService.ts";
 import LoadingSpinner from "@ui/LoadingSpinner/LoadingSpinner.tsx";
-import { AuthContext } from "@context/AuthContext/AuthContext.ts";
+import {AuthContext} from "@context/AuthContext/AuthContext.ts";
 import TypeOfSalesList from "@entities/TypeOfSalesList/TypeOfSalesList.tsx";
 import SectorsListModalItem from "@components/features/EditModal/sectors/SectorsListModalItem/SectorsListModalItem.tsx";
-import { ISector } from "@shared/onboardingTypes.ts";
-import { useFreelancerProfileAsideInfoService } from "@services/freelancer/freelancerProfileAsideInfoService.ts";
+import {ISector} from "@shared/onboardingTypes.ts";
+import {useFreelancerProfileService} from "@services/freelancer/freelancerProfileService.ts";
 
 const SectorsModalItem: React.FC<ISectorsModalItemProps> = ({ onSave, registerOnSave }) => {
 
@@ -15,18 +15,18 @@ const SectorsModalItem: React.FC<ISectorsModalItemProps> = ({ onSave, registerOn
 	const [ selectedSectors, setSelectedSectors ] = useState<ISector[]>([]);
 
 	const { patchTypeOfSales, patchSectors, loadingStatus } = useFreelancerOnboardingService();
-	const { getFreelancerData } = useFreelancerProfileAsideInfoService()
+	const { getFreelancerPrimaryInfo } = useFreelancerProfileService();
 	const { user } = useContext(AuthContext);
 
 	useEffect(() => {
 		if (!user) return;
-		getFreelancerData(user.id)
+		getFreelancerPrimaryInfo(user.id)
 			.then(data => {
 				setSelectedSectors(data.sectors ?? []);
 				setSelectedTypeOfSale(data.typeOfSales ?? null);
 			})
 			.catch(console.error)
-	}, [ setSelectedTypeOfSale, setSelectedSectors, getFreelancerData, user ]);
+	}, [ setSelectedTypeOfSale, setSelectedSectors, getFreelancerPrimaryInfo, user ]);
 
 	const handleTypeOfSaleSave = useCallback(async () => {
 		if (!selectedTypeOfSale) return;

--- a/src/components/features/FreelancerProfile/aside/PrimaryInfo/PrimaryInfo.tsx
+++ b/src/components/features/FreelancerProfile/aside/PrimaryInfo/PrimaryInfo.tsx
@@ -8,15 +8,17 @@ import StatusItem from "@ui/StatusItem/StatusItem.tsx";
 import { useModal } from "@context/ModalContext/ModalContext.ts";
 import PrimaryInfoModalItem
 	from "@components/features/EditModal/primary_info/PrimaryInfoModalItem/PrimaryInfoModalItem.tsx";
-import { useFreelancerProfileAsideInfoService } from "@services/freelancer/freelancerProfileAsideInfoService.ts";
-import { ILoggedUserResponse } from "@shared/userTypes.ts";
+import {useFreelancerProfileAsideInfoService} from "@services/freelancer/freelancerProfileAsideInfoService.ts";
+import { IFreelancerData } from "@shared/freelancer/common.ts";
+import { useFreelancerProfileService } from "@services/freelancer/freelancerProfileService.ts";
 
 const PrimaryInfo: React.FC<IFreelancerPrimaryInfoProps> = ({ freelancerId, isLoggedUserProfile }) => {
 
-	const [ freelancerData, setFreelancerData ] = useState<ILoggedUserResponse | undefined>();
+	const [ freelancerData, setFreelancerData ] = useState<IFreelancerData | undefined>();
 	const [ primaryInfo, setPrimaryInfo ] = useState<FreelancerPrimaryInfo | null>(null);
 	const { openModal } = useModal();
-	const { getFreelancerBar, getFreelancerData } = useFreelancerProfileAsideInfoService();
+	const { getFreelancerBar } = useFreelancerProfileAsideInfoService();
+	const { getFreelancerPrimaryInfo } = useFreelancerProfileService();
 
 	const fetchPrimaryInfo = useCallback(() => {
 		getFreelancerBar(freelancerId)
@@ -27,10 +29,10 @@ const PrimaryInfo: React.FC<IFreelancerPrimaryInfoProps> = ({ freelancerId, isLo
 	}, [ freelancerId, getFreelancerBar ]);
 
 	const fetchFreelancerData = useCallback(() => {
-		getFreelancerData(freelancerId)
+		getFreelancerPrimaryInfo(freelancerId)
 			.then(setFreelancerData)
 			.catch(console.error);
-	}, [ freelancerId, getFreelancerData ]);
+	}, [ freelancerId, getFreelancerPrimaryInfo ]);
 
 	useEffect(() => {
 		fetchPrimaryInfo();

--- a/src/components/features/FreelancerProfile/aside/SecondaryInfo/SecondaryInfo.tsx
+++ b/src/components/features/FreelancerProfile/aside/SecondaryInfo/SecondaryInfo.tsx
@@ -9,16 +9,17 @@ import LocalizationItem
 	from "@components/features/FreelancerProfile/aside/SecondaryInfo/LocalizationItem/LocalizationItem.tsx";
 import LanguagesItem from "@components/features/FreelancerProfile/aside/SecondaryInfo/LanguagesItem/LanguagesItem.tsx";
 import { useFreelancerProfileAsideInfoService } from "@services/freelancer/freelancerProfileAsideInfoService.ts";
-import { IFreelancerBarResponse } from "@shared/freelancer/common.ts";
+import { IFreelancerBarResponse, IFreelancerData } from "@shared/freelancer/common.ts";
 import { ISecondaryInfoProps } from "@components/features/FreelancerProfile/aside/SecondaryInfo/secondaryInfoTypes.ts";
-import { ILoggedUserResponse } from "@shared/userTypes.ts";
+import { useFreelancerProfileService } from "@services/freelancer/freelancerProfileService.ts";
 
 const SecondaryInfo: React.FC<ISecondaryInfoProps> = ({ freelancerId, isLoggedUserProfile }) => {
 
-	const { getFreelancerBar, getFreelancerData } = useFreelancerProfileAsideInfoService();
+	const { getFreelancerBar } = useFreelancerProfileAsideInfoService();
+	const { getFreelancerPrimaryInfo } = useFreelancerProfileService();
 
 	const [ freelancerInfo, setFreelancerInfo ] = useState<IFreelancerBarResponse | null>(null);
-	const [ freelancerData, setFreelancerData ] = useState<ILoggedUserResponse | undefined>(undefined);
+	const [ freelancerData, setFreelancerData ] = useState<IFreelancerData | undefined>(undefined);
 
 	const fetchFreelancerBarInfo = useCallback(() => {
 		getFreelancerBar(freelancerId)
@@ -27,10 +28,10 @@ const SecondaryInfo: React.FC<ISecondaryInfoProps> = ({ freelancerId, isLoggedUs
 	}, [ freelancerId, getFreelancerBar ]);
 
 	const fetchFreelancerData = useCallback(() => {
-		getFreelancerData(freelancerId)
-			.then(response => setFreelancerData(response))
+		getFreelancerPrimaryInfo(freelancerId)
+			.then(setFreelancerData)
 			.catch(console.error);
-	}, [ freelancerId, getFreelancerData ]);
+	}, [ freelancerId, getFreelancerPrimaryInfo ]);
 
 	useEffect(() => {
 		fetchFreelancerBarInfo();

--- a/src/components/features/FreelancerProfile/aside/SectorsInfo/SectorsInfo.tsx
+++ b/src/components/features/FreelancerProfile/aside/SectorsInfo/SectorsInfo.tsx
@@ -1,24 +1,24 @@
 import styles from "./SectorsInfo.module.scss";
 import ActionBtn from "@ui/ActionBtn/ActionBtn.tsx";
-import { useModal } from "@context/ModalContext/ModalContext.ts";
-import React, { useCallback, useEffect, useState } from "react";
-import { ISector } from "@shared/onboardingTypes.ts";
+import {useModal} from "@context/ModalContext/ModalContext.ts";
+import React, {useCallback, useEffect, useState} from "react";
+import {ISector} from "@shared/onboardingTypes.ts";
 import SectorsModalItem from "@components/features/EditModal/sectors/SectorsModalItem/SectorsModalItem.tsx";
-import { ISectorsInfoProps } from "@components/features/FreelancerProfile/aside/SectorsInfo/sectorsInfoTypes.ts";
-import { useFreelancerProfileAsideInfoService } from "@services/freelancer/freelancerProfileAsideInfoService.ts";
+import {ISectorsInfoProps} from "@components/features/FreelancerProfile/aside/SectorsInfo/sectorsInfoTypes.ts";
+import {useFreelancerProfileService} from "@services/freelancer/freelancerProfileService.ts";
 
 const SectorsInfo: React.FC<ISectorsInfoProps> = ({ freelancerId, isLoggedUserProfile }) => {
 
 	const { openModal } = useModal();
-	const { getFreelancerData } = useFreelancerProfileAsideInfoService();
+	const { getFreelancerPrimaryInfo } = useFreelancerProfileService();
 
 	const [ freelancerSectors, setFreelancerSectors ] = useState<ISector[]>([]);
 
 	const fetchFreelancerSectors = useCallback(() => {
-		getFreelancerData(freelancerId)
+		getFreelancerPrimaryInfo(freelancerId)
 			.then(data => setFreelancerSectors(data.sectors ?? []))
 			.catch(console.error);
-	}, [ freelancerId, getFreelancerData ]);
+	}, [ freelancerId, getFreelancerPrimaryInfo ]);
 
 	useEffect(() => {
 		fetchFreelancerSectors();

--- a/src/components/features/FreelancerProfile/main/FreelancerServices/FreelancerServices.tsx
+++ b/src/components/features/FreelancerProfile/main/FreelancerServices/FreelancerServices.tsx
@@ -21,8 +21,9 @@ const FreelancerServices: React.FC<IFreelancerServicesProps> = ({ freelancerId, 
 	const SECTION_ID: NavbarSectionKey = 'services';
 
 	const { openModal } = useModal();
+
 	const { getActivities, patchActivities } = useFreelancerOnboardingService();
-	const { getFreelancerActivities, createActivity } = useFreelancerProfileService()
+	const { getFreelancerActivities, createActivity } = useFreelancerProfileService();
 
 	const [ allActivities, setAllActivities ] = useState<IActivity[]>([]);
 	const [ freelancerActivities, setFreelancerActivities ] = useState<IFreelancerActivity[]>([]);

--- a/src/components/features/FreelancerProfile/main/SalesTools/SalesTools.tsx
+++ b/src/components/features/FreelancerProfile/main/SalesTools/SalesTools.tsx
@@ -67,7 +67,7 @@ const SalesTools: React.FC<ISalesToolsProps> = ({ freelancerId, isLoggedUserProf
 		});
 	};
 
-	const onSalesToolsEdit = () => {
+	const handleSalesToolsEdit = () => {
 		openModal({
 			id: 'SalesToolsEditModalItem',
 			title: 'Edytuj narzędzia sprzedażowe',
@@ -75,7 +75,9 @@ const SalesTools: React.FC<ISalesToolsProps> = ({ freelancerId, isLoggedUserProf
 			btnText: 'Zapisz zmiany',
 			withSaveBtn: true,
 			btnWithIcon: false,
-			child: <SalesToolsEditModalItem allSalesTools={ allSalesTools }/>
+			child: <SalesToolsEditModalItem
+						allSalesTools={ allSalesTools }
+						onSave={ onSalesToolsEdit }/>
 		});
 	};
 
@@ -86,6 +88,12 @@ const SalesTools: React.FC<ISalesToolsProps> = ({ freelancerId, isLoggedUserProf
 			.then(() => setSelectedSalesTool(request))
 			.catch(console.error);
 	};
+
+	const onSalesToolsEdit = (salesTools: ISalesTool[]) => {
+		patchSalesTools(salesTools.map(tool => tool.id))
+			.then(() => setSelectedSalesTool(salesTools))
+			.catch(console.error);
+	}
 
 	const handleAddTools = () => {
 		openModal({
@@ -132,7 +140,7 @@ const SalesTools: React.FC<ISalesToolsProps> = ({ freelancerId, isLoggedUserProf
                                    key={ 'Edit' }
                                    withBorder={ true }
                                    backgroundColor={ 'white' }
-                                   onClick={ onSalesToolsEdit }/>
+                                   onClick={ handleSalesToolsEdit }/>
                     </div>
 				}
 			</div>

--- a/src/components/features/Onboarding/OnboardingSwitcher.tsx
+++ b/src/components/features/Onboarding/OnboardingSwitcher.tsx
@@ -44,10 +44,10 @@ const OnboardingSwitcher = () => {
 	}, [ user, fetchLoggedUserData ]);
 
 	useEffect(() => {
-		if (step > 10) {
+		if (userData?.isOnboardingPassed) {
 			navigate("/profile");
 		}
-	}, [ step, loadingStatus, navigate ]);
+	}, [ userData, loadingStatus, navigate ]);
 
 	if (!user) {
 		return null;

--- a/src/components/features/Onboarding/OnboardingSwitcher.tsx
+++ b/src/components/features/Onboarding/OnboardingSwitcher.tsx
@@ -19,15 +19,29 @@ import LoadingSpinner from "@ui/LoadingSpinner/LoadingSpinner.tsx";
 import SalesToolsStep from "./steps/10_SalesToolsStep/SalesToolsStep.tsx";
 import btn_back from '@icons/onboarding/btn_back_icon.svg';
 import { getCurrentStepByUserAbsentData } from "@utils/onboardingUtils.ts";
+import { useAuthService } from "@services/auth/authService.ts";
+import { IFreelancerData } from "@shared/freelancer/common.ts";
 
 const OnboardingSwitcher = () => {
 	const { user, getLoggedUserData, loadingStatus } = useContext(AuthContext);
-	const [ step, setStep ] = useState<number>(0);
+
+	const { fetchLoggedUserData } = useAuthService();
+
 	const navigate = useNavigate();
 
+	const [ step, setStep ] = useState<number>(0);
+	const [ userData, setUserData ] = useState<IFreelancerData | undefined>(undefined);
+
 	useEffect(() => {
-		setStep(getCurrentStepByUserAbsentData(user));
-	}, [ user ]);
+		if (!user) return;
+
+		fetchLoggedUserData(user.role)
+			.then(response => {
+				setUserData(response);
+				setStep(getCurrentStepByUserAbsentData(response));
+			})
+			.catch(console.error);
+	}, [ user, fetchLoggedUserData ]);
 
 	useEffect(() => {
 		if (step > 10) {
@@ -60,29 +74,31 @@ const OnboardingSwitcher = () => {
 	};
 
 	const renderStepComponent = () => {
-		switch (step) {
-			case 1:
-				return <ExperienceLevelStep selectedExperience={ user.experienceLevel } onNext={ incrementStep }/>;
-			case 2:
-				return <SpecializationStep userSpecialization={ user.specialization } onNext={ incrementStep }/>;
-			case 3:
-				return <WorkingDaysStep userWorkingDays={ user.workingDays } onNext={ incrementStep }/>;
-			case 4:
-				return <WorkingHoursStep userWorkingHours={ user.workingHours } onNext={ incrementStep }/>;
-			case 5:
-				return <IncomeGoalStep userGoal={ user.incomeGoal } onNext={ incrementStep }/>;
-			case 6:
-				return <IndustryStep userSubIndustries={ user.subIndustries } onNext={ incrementStep }/>;
-			case 7:
-				return <TypeOfSalesStep userTypeOfSales={ user.typeOfSales } onNext={ incrementStep }/>;
-			case 8:
-				return <SectorStep userSectors={ user.sectors } onNext={ incrementStep }/>;
-			case 9:
-				return <ActivitiesStep userActivities={ user.selectedActivities } onNext={ incrementStep }/>;
-			case 10:
-				return <SalesToolsStep onNext={ incrementStep }/>;
-			default:
-				return <LoadingSpinner/>;
+		if(userData) {
+			switch (step) {
+				case 1:
+					return <ExperienceLevelStep selectedExperience={ userData.experienceLevel } onNext={ incrementStep }/>;
+				case 2:
+					return <SpecializationStep userSpecialization={ userData.specialization } onNext={ incrementStep }/>;
+				case 3:
+					return <WorkingDaysStep userWorkingDays={ userData.workingDays } onNext={ incrementStep }/>;
+				case 4:
+					return <WorkingHoursStep userWorkingHours={ userData.workingHours } onNext={ incrementStep }/>;
+				case 5:
+					return <IncomeGoalStep userGoal={ userData.incomeGoal } onNext={ incrementStep }/>;
+				case 6:
+					return <IndustryStep userSubIndustries={ userData.subIndustries } onNext={ incrementStep }/>;
+				case 7:
+					return <TypeOfSalesStep userTypeOfSales={ userData.typeOfSales } onNext={ incrementStep }/>;
+				case 8:
+					return <SectorStep userSectors={ userData.sectors } onNext={ incrementStep }/>;
+				case 9:
+					return <ActivitiesStep userActivities={ userData.selectedActivities } onNext={ incrementStep }/>;
+				case 10:
+					return <SalesToolsStep onNext={ incrementStep }/>;
+				default:
+					return <LoadingSpinner/>;
+			}
 		}
 	};
 
@@ -90,8 +106,8 @@ const OnboardingSwitcher = () => {
 		return <LoadingSpinner/>;
 	}
 
-	if (step === 0) {
-		return <WelcomeStep onNext={ incrementStep } username={ user.firstName + " " + user.lastName }/>;
+	if (step === 0 && userData) {
+		return <WelcomeStep onNext={ incrementStep } username={ userData.firstName + " " + userData.lastName }/>;
 	}
 
 	return (

--- a/src/components/layout/navbar/ProfileNavbar/ProfileNavbar.module.scss
+++ b/src/components/layout/navbar/ProfileNavbar/ProfileNavbar.module.scss
@@ -112,16 +112,18 @@
       }
     }
 
-    &--active {
-      svg path {
+    &--arrow {
         transform: rotate(-180deg);
         transform-origin: center;
         transition: transform 0.5s;
-      }
     }
 
     &--pl43 {
       padding-left: 43px;
+    }
+
+    &--pl35 {
+      padding-left: 35px;
     }
   }
 

--- a/src/components/layout/navbar/ProfileNavbar/ProfileNavbar.tsx
+++ b/src/components/layout/navbar/ProfileNavbar/ProfileNavbar.tsx
@@ -107,14 +107,14 @@ const ProfileNavbar = () => {
 						className={ `btn btn--more 
 									 ${ styles["navbar__btn"] }
 									 ${ styles["navbar__btn--avatar"] }
-					 				 ${ avatar && styles["navbar__btn--pl43"] } 
+					 				 ${ avatar ? styles["navbar__btn--pl43"] : styles["navbar__btn--pl35"] } 
 					 				 ${ isDropdownOpened && styles["navbar__btn--active"] }`}
 						onClick={ () => setIsDropdownOpened(!isDropdownOpened) }>
 						<div className={ `${ styles["navbar__avatar"] }`}>
 							{ avatar ? <img src={ avatar } alt="avatar"/> : <GuardianIcon/> }
 						</div>
 						{ user?.firstName } { user?.lastName }
-						 <ArrowDown className={ `${ isDropdownOpened && styles["navbar__btn--active"] }` }/>
+						 <ArrowDown className={ `${ isDropdownOpened && styles["navbar__btn--arrow"] }` }/>
 					</button>
 					<DropDownModal isOpen={ isDropdownOpened }
 								   renderItems={ renderAvatarOptions() }

--- a/src/context/AuthContext/AuthContext.ts
+++ b/src/context/AuthContext/AuthContext.ts
@@ -1,6 +1,6 @@
-import {createContext} from "react";
-import {LoadingStatusOptions} from "@hooks/http.hook.ts";
-import {ILoggedUserData} from "@shared/userTypes.ts";
+import { createContext } from "react";
+import { LoadingStatusOptions } from "@hooks/http.hook.ts";
+import { ILoggedUserData } from "@shared/userTypes.ts";
 
 export const InitialAuthState: IAuthInitialState = {
 	user: null,

--- a/src/context/AuthContext/AuthContext.ts
+++ b/src/context/AuthContext/AuthContext.ts
@@ -16,7 +16,7 @@ export interface IAuthInitialState {
 
 export interface IAuthContextValue extends IAuthInitialState {
 	logout: () => void;
-	getLoggedUserData: (token: string) => void;
+	getLoggedUserData: (token: string) => Promise<ILoggedUserData | void>;
 }
 
 export const AuthContext = createContext<IAuthContextValue>({
@@ -24,5 +24,5 @@ export const AuthContext = createContext<IAuthContextValue>({
 	loadingStatus: InitialAuthState.loadingStatus,
 	errorMessage: InitialAuthState.errorMessage,
 	logout: () => {},
-	getLoggedUserData: () => {},
+	getLoggedUserData: () => Promise.resolve(),
 });

--- a/src/context/AuthContext/AuthProvider.tsx
+++ b/src/context/AuthContext/AuthProvider.tsx
@@ -3,7 +3,7 @@ import {useAuthService} from "@services/auth/authService.ts";
 import {authReducer} from "./authReducer.ts";
 import {AuthActionType} from "./authActions.ts";
 import {AuthContext, IAuthContextValue, InitialAuthState} from "./AuthContext.ts";
-import { ILoggedUserResponse, UserRole } from "@shared/userTypes.ts";
+import {ILoggedUserResponse, UserRole} from "@shared/userTypes.ts";
 import {jwtDecode} from "jwt-decode";
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -16,14 +16,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 		dispatch({ type: AuthActionType.LOGOUT });
 	}, []);
 
-	const getLoggedUserData = useCallback((currentToken: string) => {
+	const getLoggedUserData = useCallback(async (currentToken: string) => {
 		dispatch({ type: AuthActionType.SET_LOADING_STATUS, payload: 'loading' });
 
 		const role = getUserRole(currentToken);
 
-		fetchLoggedUserData(role)
+		return fetchLoggedUserData(role)
 			.then((response: ILoggedUserResponse) => {
-				dispatch({ type: AuthActionType.GET_LOGGED_USER, payload: { role, ...response } });
+				const userData =  { role, ...response };
+				dispatch({ type: AuthActionType.GET_LOGGED_USER, payload: userData });
+				return userData;
 			})
 			.catch(e => {
 					dispatch({ type: AuthActionType.SET_ERROR, payload: errorMessage ?? e });

--- a/src/context/AuthContext/AuthProvider.tsx
+++ b/src/context/AuthContext/AuthProvider.tsx
@@ -3,7 +3,7 @@ import {useAuthService} from "@services/auth/authService.ts";
 import {authReducer} from "./authReducer.ts";
 import {AuthActionType} from "./authActions.ts";
 import {AuthContext, IAuthContextValue, InitialAuthState} from "./AuthContext.ts";
-import {ILoggedUserResponse, UserRole} from "@shared/userTypes.ts";
+import { ILoggedUserResponse, UserRole } from "@shared/userTypes.ts";
 import {jwtDecode} from "jwt-decode";
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -1,8 +1,13 @@
 import { useHttp } from "@hooks/http.hook.ts";
 import { useCallback } from "react";
-import { ICreateUserRequest, ICreateUserResponse, ILoggedUserResponse, UserRole } from "@shared/userTypes.ts";
+import {
+	ICreateUserRequest,
+	ICreateUserResponse,
+	UserRole
+} from "@shared/userTypes.ts";
 import { ILoginRequest, ILoginResponse } from "@shared/authTypes.ts";
 import { API_ROUTES } from "@constants/apiRoutes.ts";
+import { IFreelancerData } from "@shared/freelancer/common.ts";
 
 export const useAuthService = () => {
 	const { sendRequest, loadingStatus, errorMessage } = useHttp();
@@ -28,7 +33,7 @@ export const useAuthService = () => {
 		});
 	}, [ sendRequest ]);
 
-	const fetchLoggedUserData = useCallback(async (role: string): Promise<ILoggedUserResponse> => {
+	const fetchLoggedUserData = useCallback(async (role: string): Promise<IFreelancerData> => {
 		const url = role === 'FREELANCER'
 			? API_ROUTES.USER.FREELANCER_PROFILE
 			: API_ROUTES.USER.INVESTOR_PROFILE;

--- a/src/services/freelancer/freelancerProfileAsideInfoService.ts
+++ b/src/services/freelancer/freelancerProfileAsideInfoService.ts
@@ -1,7 +1,7 @@
 import { useHttp } from "@hooks/http.hook.ts";
 import { useCallback } from "react";
 import { API_ROUTES } from "@constants/apiRoutes.ts";
-import { IFreelancerBarResponse, IFreelancerNameRequest } from "@shared/freelancer/common.ts";
+import { IFreelancerBarResponse, IFreelancerData, IFreelancerNameRequest } from "@shared/freelancer/common.ts";
 import {
 	IFreelancerCountry,
 	IFreelancerLocalization,
@@ -9,16 +9,9 @@ import {
 	IFreelancerWorkingArea
 } from "@shared/freelancer/localization.ts";
 import { IFreelancerLanguage, ILanguage } from "@shared/freelancer/language.ts";
-import { ILoggedUserResponse } from "@shared/userTypes.ts";
 
 export const useFreelancerProfileAsideInfoService = () => {
 	const { sendRequest, loadingStatus, errorMessage } = useHttp();
-
-	const getFreelancerData = useCallback(async (freelancerId: number): Promise<ILoggedUserResponse> => {
-		return await sendRequest({
-			url: `${ API_ROUTES.USER.FREELANCER_PROFILE }/${ freelancerId }`,
-		})
-	}, [ sendRequest ]);
 
 	const getFreelancerBar = useCallback(async (freelancerId: number): Promise<IFreelancerBarResponse> => {
 		return await sendRequest({
@@ -87,7 +80,6 @@ export const useFreelancerProfileAsideInfoService = () => {
 	return {
 		loadingStatus,
 		errorMessage,
-		getFreelancerData,
 		getFreelancerBar,
 		patchFreelancerName,
 		patchFreelancerCompany,

--- a/src/services/freelancer/freelancerProfileService.ts
+++ b/src/services/freelancer/freelancerProfileService.ts
@@ -1,9 +1,8 @@
 import { useHttp } from "@hooks/http.hook.ts";
 import { useCallback } from "react";
 import { API_ROUTES } from "@constants/apiRoutes.ts";
-import { IAboutMeInfo, IFreelancerBackgroundResponse } from "@shared/freelancer/common.ts";
+import { IAboutMeInfo, IFreelancerBackgroundResponse, IFreelancerData } from "@shared/freelancer/common.ts";
 import { IFreelancerReview } from "@shared/freelancer/review.ts";
-import { ILoggedUserResponse } from "@shared/userTypes.ts";
 import { ISalesTool } from "@shared/onboardingTypes.ts";
 import { IActivityRequest, IFreelancerActivity } from "@shared/onboardingTypes.ts";
 
@@ -61,7 +60,7 @@ export const useFreelancerProfileService = () => {
 			});
 		}, [ sendRequest ]);
 
-	const getFreelancerPrimaryInfo = useCallback(async (freelancerId: number): Promise<ILoggedUserResponse> => {
+	const getFreelancerPrimaryInfo = useCallback(async (freelancerId: number): Promise<IFreelancerData> => {
 		return await sendRequest({
 			url: `${ API_ROUTES.USER.FREELANCER_PROFILE }/${ freelancerId }`
 		});

--- a/src/shared/freelancer/common.ts
+++ b/src/shared/freelancer/common.ts
@@ -1,6 +1,11 @@
 import { IFreelancerLocalization } from "@shared/freelancer/localization.ts";
 import { WORKING_AREAS } from "@constants/workingAreas.ts";
 import { IFreelancerLanguage } from "@shared/freelancer/language.ts";
+import { EXPERIENCE_LEVELS } from "@constants/experienceLevel.ts";
+import { IFreelancerActivity, ISalesTool, ISector, ISpecialization, ISubIndustry } from "@shared/onboardingTypes.ts";
+import { WorkingDayKey } from "@constants/workingDays.ts";
+import { IFreelancerWorkExperience } from "@shared/freelancer/work-experience.ts";
+import { ILoggedUserResponse } from "@shared/userTypes.ts";
 
 export interface IFreelancerBackgroundResponse {
 	id: number;
@@ -31,4 +36,20 @@ export interface IAboutMeInfo {
 	about: string | null;
 	video: string | null;
 	mainPassion: string | null;
+}
+
+export interface IFreelancerData extends ILoggedUserResponse {
+	experienceLevel: keyof typeof EXPERIENCE_LEVELS;
+	company: string;
+	specialization: ISpecialization,
+	workingDays: WorkingDayKey[];
+	workingHours: string;
+	incomeGoal: string;
+	subIndustries: ISubIndustry[],
+	typeOfSales: string;
+	sectors: ISector[];
+	selectedActivities: IFreelancerActivity[],
+	salesTools: ISalesTool[];
+	workExperiences: IFreelancerWorkExperience[];
+	isOnboardingPassed: boolean;
 }

--- a/src/shared/userTypes.ts
+++ b/src/shared/userTypes.ts
@@ -1,8 +1,3 @@
-import { IFreelancerActivity, ISalesTool, ISector, ISpecialization, ISubIndustry } from "./onboardingTypes.ts";
-import { EXPERIENCE_LEVELS } from "@constants/experienceLevel.ts";
-import { WorkingDayKey } from "@constants/workingDays.ts";
-import { IFreelancerWorkExperience } from "@shared/freelancer/work-experience.ts";
-
 export type UserRole = 'FREELANCER' | 'INVESTOR';
 
 export interface ICreateUserRequest {
@@ -25,19 +20,6 @@ export interface ILoggedUserResponse {
 	email: string;
 	firstName: string;
 	lastName: string;
-	experienceLevel: keyof typeof EXPERIENCE_LEVELS;
-	company: string;
-	specialization: ISpecialization,
-	workingDays: WorkingDayKey[];
-	workingHours: string;
-	incomeGoal: string;
-	subIndustries: ISubIndustry[],
-	typeOfSales: string;
-	sectors: ISector[];
-	selectedActivities: IFreelancerActivity[],
-	salesTools: ISalesTool[];
-	workExperiences: IFreelancerWorkExperience[];
-	isOnboardingPassed: boolean;
 }
 
 export interface IUserAvatarResponse {

--- a/src/shared/userTypes.ts
+++ b/src/shared/userTypes.ts
@@ -20,6 +20,7 @@ export interface ILoggedUserResponse {
 	email: string;
 	firstName: string;
 	lastName: string;
+	isOnboardingPassed: boolean | undefined;
 }
 
 export interface IUserAvatarResponse {

--- a/src/utils/onboardingUtils.ts
+++ b/src/utils/onboardingUtils.ts
@@ -1,10 +1,6 @@
 import { IFreelancerData } from "@shared/freelancer/common.ts";
 
-export const getCurrentStepByUserAbsentData = (user: IFreelancerData | null): number => {
-	const undefinedNumber = 11;
-	if (!user) {
-		return undefinedNumber;
-	}
+export const getCurrentStepByUserAbsentData = (user: IFreelancerData): number => {
 	if (user.experienceLevel === null) {
 		return 0;
 	}
@@ -35,5 +31,5 @@ export const getCurrentStepByUserAbsentData = (user: IFreelancerData | null): nu
 	if (user.salesTools.length === 0) {
 		return 10;
 	}
-	return undefinedNumber;
+	return 11;
 };

--- a/src/utils/onboardingUtils.ts
+++ b/src/utils/onboardingUtils.ts
@@ -1,6 +1,6 @@
-import {ILoggedUserData} from "@shared/userTypes.ts";
+import { IFreelancerData } from "@shared/freelancer/common.ts";
 
-export const getCurrentStepByUserAbsentData = (user: ILoggedUserData | null): number => {
+export const getCurrentStepByUserAbsentData = (user: IFreelancerData | null): number => {
 	const undefinedNumber = 11;
 	if (!user) {
 		return undefinedNumber;


### PR DESCRIPTION
1. Fixing Navigate in LoginForm moving user to onboarding if it's freelancer ( to avoid unnecessary re-renders ), to profile if it's other role
2. Refactor SalesToolsEditModal:
- delete context
- adding onSave action to render new Sales Tools on profile 
3. Delete duplicated endpoint in useFreelancerProfileAsideInfoService now it's only in useFreelancerProfileService
4. Changing onboarding Switcher 
- remove context
- adding new condition to navigate to profile
- add get freelancer by id
- adding new conditions to protect render errors
5. Changing ProtectedRoutes:
- now if users role is freelancer we get /Me to get isOnboardingPassed value
- remove context 
6. Adding Padding left to ProfileNavbar avatar when there is no avatar to avoid bug with icon placed on name additional fix bug with rotating all icon separate avatar icon and arrow icon
7. Adding new interface IFreelancerData to keep freelancerMe data 
8. Replacing all endpoints with FreelancerMe on IFreelancerData and adding this type to onboardingUtils